### PR TITLE
bin/install.ps1: Also look for `JuliaProject.toml`

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -57,7 +57,7 @@ if ($env:APPVEYOR_REPO_NAME -match "(\w+?)\/(\w+?)(?:\.jl)?$") {
 }
 
 if ($julia_version -ge [Version]"0.7") {
-    if (Test-Path "Project.toml") {
+    if (Test-Path "Project.toml" -or Test-Path "JuliaProject.toml") {
         $env:JULIA_PROJECT = "@." # TODO: change this to --project="@."
         $env:JL_BUILD_SCRIPT = "using Pkg; Pkg.build()"
         $env:JL_TEST_SCRIPT = "using Pkg; Pkg.test(coverage=true)"


### PR DESCRIPTION
The name `JuliaProject.toml` [takes precedence over `Project.toml`](https://docs.julialang.org/en/v1/manual/code-loading/#Project-environments-1) and is often preferred in a multi-language repository.

I'm not familiar with this scripting language so I'm hoping this is valid syntax.

Thanks to @/fredrikekre for catching this (with [impressively minimal information](https://discourse.julialang.org/t/julia-v1-4-0-rc1-is-now-available/33715/34?u=tkluck))!